### PR TITLE
Update to prevent clearing existing notifications in DispatcherHintShower

### DIFF
--- a/DVDispatcherMod/DispatcherHintShowers/DispatcherHintShower.cs
+++ b/DVDispatcherMod/DispatcherHintShowers/DispatcherHintShower.cs
@@ -28,7 +28,7 @@ namespace DVDispatcherMod.DispatcherHintShowers {
             if (dispatcherHintOrNull != null) {
                 var transform = GetAttentionTransform(dispatcherHintOrNull.AttentionPoint);
 
-                _notification = _notificationManager.ShowNotification(dispatcherHintOrNull.Text, pointAt: transform, localize: false);
+                _notification = _notificationManager.ShowNotification(dispatcherHintOrNull.Text, pointAt: transform, localize: false, clearExisting: false);
             }
         }
 


### PR DESCRIPTION
This just adds a clearExisting: false flag so that current notifications are not cleared.

This fixes the conflict with TwitchChat mod and clearing chat message notifications.