### PR TITLE
Fix for B99.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -348,3 +348,4 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+/Directory.Build.Props

--- a/DVDispatcherMod/DVDispatcherMod.csproj
+++ b/DVDispatcherMod/DVDispatcherMod.csproj
@@ -22,6 +22,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <LangVersion>9</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -30,6 +31,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <LangVersion>9</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Assembly-CSharp">
@@ -42,6 +44,12 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="DV.Inventory">
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="DV.PointSet">
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="DV.RailTrack">
       <Private>False</Private>
     </Reference>
     <Reference Include="DV.Scenarios.CRUD">
@@ -94,6 +102,9 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityModManager">
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="VRTK">
       <Private>False</Private>
     </Reference>
   </ItemGroup>

--- a/DVDispatcherMod/DispatcherHintShowers/DispatcherHintShower.cs
+++ b/DVDispatcherMod/DispatcherHintShowers/DispatcherHintShower.cs
@@ -47,10 +47,10 @@ namespace DVDispatcherMod.DispatcherHintShowers {
                 _notification = null;
             }
 
-            var gameObject = _attentionLineTransform?.gameObject;
-            if (gameObject != null) {
-                Object.Destroy(gameObject);
-            }
+            if (_attentionLineTransform)
+            {
+                Object.Destroy(_attentionLineTransform.gameObject);
+            }    
         }
     }
 }


### PR DESCRIPTION
- Updated reference names
- Added reference to new VRTK (actual VR testing needed!)
- Changed Dispose methods to properly remove game objects after exit to main menu

Mod now works fine in B99.7, no longer [blocks other](https://github.com/Banjobeni/DerailValley-PersistentJobs/issues/41) mod´s console commands. Is again usable after exiting to the main menu and then loading a save. Integration with PaxJobs from #1 works.

Prebuilt files [here:](https://github.com/user-attachments/files/21957814/DVDispatcherMod.zip)